### PR TITLE
Update resources.yml

### DIFF
--- a/static/data/resources.yml
+++ b/static/data/resources.yml
@@ -604,7 +604,7 @@
 - link: https://eosknights.io/
   description: EOS Knights
   tag:
-  - EOS
+  - eos
   - game
   - collectible
   


### PR DESCRIPTION
Merge "eos" tags together; "EOS" (all caps) was causing the "eos" tag to be displayed twice in the list.